### PR TITLE
Increase visibility of UnionScopeBuilder and and the Scopes property of UnionScope

### DIFF
--- a/Nitra/Nitra.Runtime/Typing2/Scope/UnionScope.n
+++ b/Nitra/Nitra.Runtime/Typing2/Scope/UnionScope.n
@@ -16,7 +16,7 @@ namespace Nitra.Declarations
 {
   public sealed class UnionScope : Scope
   {
-    internal Scopes : array[Scope] { get; }
+    public Scopes : array[Scope] { get; }
 
     internal this(scopes : array[Scope])
     {

--- a/Nitra/Nitra.Runtime/Typing2/Scope/UnionScopeBuilder.n
+++ b/Nitra/Nitra.Runtime/Typing2/Scope/UnionScopeBuilder.n
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Nitra.Declarations
 {
-  internal struct UnionScopeBuilder
+  public struct UnionScopeBuilder
   {
     mutable _scopes : HashSet[Scope];
     mutable _scope1 : Scope;


### PR DESCRIPTION
### `UnionScopeBuilder`

It seems reasonable to allow usage of UnionScopeBuilder directly. Doing something like the following is unpleasant and creates overhead for the GC:
```Nemerle
foreach(scope in scopes)
{
  firstScope = firstScope.UnionWith(scope);
}
```

### Scopes property of `UnionScope`

For simpler debugging in the Visualizer the property should be public. It's readonly anyway, so there is no harm in that.