### PR TITLE
[VS Plugin] Build project when solution is built

### DIFF
--- a/Nitra.LanguageCompiler/Templates/XXLanguageFullNameXXVsPackage/XXLanguageFullNameXXVsPackage.sln
+++ b/Nitra.LanguageCompiler/Templates/XXLanguageFullNameXXVsPackage/XXLanguageFullNameXXVsPackage.sln
@@ -12,7 +12,9 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9FA006E7-62F9-4E9A-B6CF-C0B6E79FACBF}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{9FA006E7-62F9-4E9A-B6CF-C0B6E79FACBF}.Debug|Any CPU.Build.0 = Debug|x86
 		{9FA006E7-62F9-4E9A-B6CF-C0B6E79FACBF}.Release|Any CPU.ActiveCfg = Release|x86
+		{9FA006E7-62F9-4E9A-B6CF-C0B6E79FACBF}.Release|Any CPU.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Building the generated plugin in VisualStudio or by running MSBuild against the .sln file (instead of the csproj) didn't do anything because the project was not selected to be built.

Effectively sets the checkmark of the "Build" column in the configuration-tab of the solution's properties.