### PR TITLE
[Plugin Generator] Prevent usage of wrong app.config

### DIFF
--- a/Nitra.LanguageCompiler/App.config
+++ b/Nitra.LanguageCompiler/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  This configuration file is required, even though it is empty:
+  It prevents the app.config of the plugin-template from being wrongly used as configuration file for the actual application.
+-->
+<configuration>
+</configuration>

--- a/Nitra.LanguageCompiler/Nitra.LanguageCompiler.nproj
+++ b/Nitra.LanguageCompiler/Nitra.LanguageCompiler.nproj
@@ -45,7 +45,7 @@
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-      <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <StartProgram />
@@ -93,6 +93,9 @@
     <Compile Include="Utils.n">
       <SubType>Code</SubType>
     </Compile>
+    <Content Include="App.config">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="ExternalDependencies\ReadMy.txt">
       <SubType>Content</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Visual Studio automatically assumed the app.config of the plugin template to be the the desired one for the LanguageCompiler.

An empty app.config in the project's root directory takes precedence and prevents this.

This caused a crash because of [an assembly binding redirect](https://github.com/rsdn/nitra/blob/464d6fc76b72c4339c02da8281c6da2e1f1de8c7/Nitra.LanguageCompiler/Templates/XXLanguageFullNameXXVsPackage/app.config#L9-L12) that could not be satisfied.