### PR TITLE
[VS Plugin] Fix GetCurrentProjectId()

### DIFF
--- a/Ide/NitraCommonVSIX/Models/TextViewModel.cs
+++ b/Ide/NitraCommonVSIX/Models/TextViewModel.cs
@@ -243,7 +243,7 @@ namespace Nitra.VisualStudio.Models
     ProjectId GetCurrntProjectId()
     {
       var project = FileModel.Hierarchy.GetProject();
-      return new ProjectId(FileModel.Server.Client.StringManager.GetId(project.FileName));
+      return new ProjectId(FileModel.Server.Client.StringManager.GetId(project.FullName));
     }
 
     static void GoToLocation(FileModel fileModel, Location loc)


### PR DESCRIPTION
Nemerle projects only return `Project.nproj` instead of `C:\full\path\to\Project.nproj` when calling `project.FileName`. For `.csproj` files the full path is returned in both cases.